### PR TITLE
`hits` array should be populated only when there are recommendations

### DIFF
--- a/app.py
+++ b/app.py
@@ -91,12 +91,15 @@ async def recommendations(msg_id: str, topic: str, message: dict):
                     hosts = json.loads(json_data.decode())['hosts']
 
                     for _host_id, host_info in hosts.items():
-                        hits = [
-                            {
-                                'rule_id': rule_id,
-                                'details': host_info
-                            }
-                        ]
+                        if host_info['recommendations']:
+                            hits = [
+                                {
+                                    'rule_id': rule_id,
+                                    'details': host_info
+                                }
+                            ]
+                        else:
+                            hits = []
 
                         host_item = {
                             'source': 'aiops',


### PR DESCRIPTION
Per the Advisor doc, https://docs.google.com/document/d/11nEhHsqFVaRcBQ7Q3f6W2Z4eXm9DTqnw79pVZULuqkg/edit#heading=h.20cl9rffk5j0

`hits` array needs to be empty if there are no issues/recommendations for a given host.