### PR TITLE
Use AI_SERVICE from the environment to set the rule_id and also the source key

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,7 +54,7 @@ VALIDATE_PRESENCE = {'url'}
 MAX_RETRIES = 3
 
 
-async def recommendations(msg_id: str, topic: str, message: dict):
+async def recommendations(msg_id: str, message: dict):
     """Retrieve recommendations JSON from the TAR file in s3.
 
     Make an async HTTP GET call to the s3 bucket endpoint
@@ -136,7 +136,6 @@ async def process_message(message: ConsumerRecord) -> bool:
 
     # Parse the message as JSON
     try:
-        topic = message.topic
         content = json.loads(message.value)
     except ValueError as e:
         logger.error(
@@ -152,7 +151,7 @@ async def process_message(message: ConsumerRecord) -> bool:
         return False
 
     try:
-        await recommendations(msg_id, topic, content)
+        await recommendations(msg_id, content)
     except aiohttp.ClientError:
         logger.warning('Message %s: Unable to pass message', msg_id)
         return False

--- a/app.py
+++ b/app.py
@@ -98,7 +98,7 @@ async def recommendations(msg_id: str, message: dict):
         if host_info['recommendations']:
             hits.append(
                 {
-                    'rule_id': AI_SERVICE,
+                    'rule_id': AI_SERVICE.replace("-", "_"),
                     'details': host_info
                 }
             )


### PR DESCRIPTION
`AI_SERVICE` from the environment could be used to set the following in the Advisor JSON -

- rule_id
- source

This way we don't have to maintain a dict for rules.
And, `source` would be unique for each namespace/use case/AI_SERVICE

Also, with 
- https://github.com/RedHatInsights/e2e-deploy/pull/158
- ManageIQ/aiops-dummy-ai-service#16
- ManageIQ/aiops-publisher#19

the recommendations would now be published on this topic -- `platform.upload.{{ai_service}}`, which could be used in the deployment config for aiops-consumer for the `KAFKA_CONSUMER_TOPIC` variable.

