### PR TITLE
Add common_data to each host

### DIFF
--- a/app.py
+++ b/app.py
@@ -91,13 +91,14 @@ async def recommendations(msg_id: str, message: dict):
     data = await tar_extractor.extract(BytesIO(data))
 
     # JSON Processing
-    hosts = json.loads(data.decode())['hosts']
+    json_data = json.loads(data.decode())
 
-    for host_info in hosts.values():
+    for host_info in json_data['hosts'].values():
         hits = []
         if host_info['recommendations']:
             rule = AI_SERVICE.replace("-", "_")
             rule_id = f'{rule}|{rule.upper()}'
+            host_info['common_data'] = json_data.get('common_data', {})
             hits.append(
                 {
                     'rule_id': rule_id,


### PR DESCRIPTION
For the Anomaly detection use case, there is a section in the JSON under `common_data` which is applicable to all hosts.

So in the PR, the Consumer looks for `common_data` and attaches it to every host (in `host_info`)

P.S. Let's leave this PR open for some time and not merge it
Chances are we would not be showing the Anomaly detection results in Advisor (I just came to know about this) 
If that is the case, we don't need this change right now.
/cc @bronaghs 