### PR TITLE
Accommodate for multiple rule_ids via `recommendations`

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,6 +54,23 @@ VALIDATE_PRESENCE = {'url'}
 MAX_RETRIES = 3
 
 
+async def hits_with_rules(host_info: dict):
+    """Populate hits list with rule_id and details."""
+    hits = []
+    rules = host_info['recommendations'].get(
+        'applicable_rules', [AI_SERVICE.replace("-", "_")]
+    )
+    for rule in rules:
+        rule_id = f'{rule}|{rule.upper()}'
+        hits.append(
+            {
+                'rule_id': rule_id,
+                'details': host_info
+            }
+        )
+    return hits
+
+
 async def recommendations(msg_id: str, message: dict):
     """Retrieve recommendations JSON from the TAR file in s3.
 
@@ -96,14 +113,7 @@ async def recommendations(msg_id: str, message: dict):
     for host_info in hosts.values():
         hits = []
         if host_info['recommendations']:
-            rule = AI_SERVICE.replace("-", "_")
-            rule_id = f'{rule}|{rule.upper()}'
-            hits.append(
-                {
-                    'rule_id': rule_id,
-                    'details': host_info
-                }
-            )
+            hits = await hits_with_rules(host_info)
 
         output = {
             'source': AI_SERVICE,

--- a/app.py
+++ b/app.py
@@ -57,17 +57,17 @@ MAX_RETRIES = 3
 async def hits_with_rules(host_info: dict):
     """Populate hits list with rule_id and details."""
     hits = []
-    rules = host_info['recommendations'].get(
-        'applicable_rules', [AI_SERVICE.replace("-", "_")]
-    )
+
+    # By default we use the AI_SERVICE as rule type indicator
+    rules = [AI_SERVICE.replace("-", "_")]
+
+    # In case the host recommendation should be generated for multiple rules,
+    # list all rules
+    rules = host_info['recommendations'].get('applicable_rules', rules)
+
     for rule in rules:
         rule_id = f'{rule}|{rule.upper()}'
-        hits.append(
-            {
-                'rule_id': rule_id,
-                'details': host_info
-            }
-        )
+        hits.append({'rule_id': rule_id, 'details': host_info})
     return hits
 
 


### PR DESCRIPTION
For the Idle Cost Savings/Instance Cost Savings use case, we could have a per-host JSON that has both type of Recommendations. For a case like this, we would need that host to have 2 Rule hits as opposed to 1. 
The Rule Id's for these Rule hits would be specified in the `recommendations` under `applicable_rules` -- all the Consumer needs to do is create a `hits` list that contains these Rule Id's

Related: https://github.com/ManageIQ/aiops-ai-library/pull/30
